### PR TITLE
Add referer url in error.log

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -296,6 +296,11 @@ abstract class BaseErrorHandler
             $request = Router::getRequest();
             if ($request) {
                 $message .= "\nRequest URL: " . $request->here();
+
+                $referer = $request->env('HTTP_REFERER');
+                if ($referer) {
+                    $message .= "\nReferer URL: " . $referer;
+                }
             }
         }
         if (!empty($config['trace'])) {


### PR DESCRIPTION
Add referer URL in error log, below Request URL.
If the referal is '/' ignore it because it was a direct visit